### PR TITLE
Add simple text humanizer endpoint

### DIFF
--- a/humanizer.js
+++ b/humanizer.js
@@ -1,0 +1,39 @@
+// Simple text humanizer
+// Replaces formal words with simpler alternatives and adds occasional fillers
+
+const synonyms = {
+  utilize: 'use',
+  obtain: 'get',
+  numerous: 'many',
+  individual: 'person',
+  assist: 'help',
+  facilitate: 'help',
+  commence: 'start',
+  terminate: 'end',
+};
+
+function humanizeText(text) {
+  let result = text;
+  for (const [aiWord, humanWord] of Object.entries(synonyms)) {
+    const regex = new RegExp(`\\b${aiWord}\\b`, 'gi');
+    result = result.replace(regex, humanWord);
+  }
+
+  const fillers = ['like', 'you know', 'actually', 'basically'];
+  result = result
+    .split(/([.!?])/)
+    .map((segment, idx) => {
+      if (idx % 2 === 0 && segment.trim()) {
+        if (Math.random() < 0.3) {
+          const filler = fillers[Math.floor(Math.random() * fillers.length)];
+          return segment.trim() + ', ' + filler;
+        }
+      }
+      return segment;
+    })
+    .join('');
+
+  return result;
+}
+
+module.exports = { humanizeText };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const fetch = require('node-fetch');
+const { humanizeText } = require('./humanizer');
 
 const app = express();
 app.use(express.json());
@@ -28,6 +29,16 @@ app.post('/', async (req, res) => {
   });
 
   res.sendStatus(200);
+});
+
+// Simple API endpoint to humanize text
+app.post('/humanize', (req, res) => {
+  const { text } = req.body;
+  if (!text) {
+    return res.status(400).json({ error: 'text is required' });
+  }
+  const humanized = humanizeText(text);
+  res.json({ humanized });
 });
 
 const PORT = process.env.PORT || 3000;


### PR DESCRIPTION
## Summary
- add simple text humanizer module
- expose /humanize endpoint in the bot

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847b7f7a2588322a6512aaf45fac25f